### PR TITLE
🐛 Fix finishing of ProcessInstances in correlations

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Contains the commonly used contracts for the Correlation API.",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/src/icorrelation_repository.ts
+++ b/src/icorrelation_repository.ts
@@ -110,22 +110,25 @@ export interface ICorrelationRepository {
    * @param   processModelId The ID of the processModel, by which Correlations should be removed.
    */
   deleteCorrelationByProcessModelId(correlationId: string): Promise<void>;
-  /**
-   * Finishes the given Correlation.
-   *
-   * @async
-   * @param  correlationId    The ID of the Correlation to finish.
-   * @throws {NotFoundError}  When no matching correlation was found.
-   */
-  finishProcessInstanceInCorrelation(correlationId: string): Promise<void>;
 
   /**
-   * Finishes the given Correlation with an error.
+   * Finishes the given ProcessInstance in the given Correlation.
    *
    * @async
-   * @param  correlationId    The ID of the Correlation to finish erroneously.
-   * @param  error            The error that occurred.
-   * @throws {NotFoundError}  When no matching correlation was found.
+   * @param  correlationId     The ID of the Correlation to finish.
+   * @param  processInstanceId The ID of the ProcessInstance to finish.
+   * @throws {NotFoundError}   When no matching correlation was found.
    */
-  finishProcessInstanceInCorrelationWithError(correlationId: string, error: Error): Promise<void>;
+  finishProcessInstanceInCorrelation(correlationId: string, processInstanceId: string): Promise<void>;
+
+  /**
+   * Finishes the given ProcessInstance in the given Correlation with an error.
+   *
+   * @async
+   * @param  correlationId     The ID of the Correlation to finish erroneously.
+   * @param  processInstanceId The ID of the ProcessInstance to finish.
+   * @param  error             The error that occurred.
+   * @throws {NotFoundError}   When no matching correlation was found.
+   */
+  finishProcessInstanceInCorrelationWithError(correlationId: string, processInstanceId: string, error: Error): Promise<void>;
 }

--- a/src/icorrelation_repository.ts
+++ b/src/icorrelation_repository.ts
@@ -110,23 +110,22 @@ export interface ICorrelationRepository {
    * @param   processModelId The ID of the processModel, by which Correlations should be removed.
    */
   deleteCorrelationByProcessModelId(correlationId: string): Promise<void>;
-
   /**
    * Finishes the given Correlation.
    *
    * @async
-   * @param   correlationId   The ID of the Correlation to finish.
-   * @throws  NotFoundError  When no matching Correlation was found.
+   * @param  correlationId    The ID of the Correlation to finish.
+   * @throws {NotFoundError}  When no matching correlation was found.
    */
-  finishCorrelation(correlationId: string): Promise<void>;
+  finishProcessInstanceInCorrelation(correlationId: string): Promise<void>;
 
   /**
    * Finishes the given Correlation with an error.
    *
    * @async
-   * @param   correlationId   The ID of the Correlation to finish erroneously.
-   * @param   error           The error that occurred.
-   * @throws  NotFoundError  When no matching Correlation was found.
+   * @param  correlationId    The ID of the Correlation to finish erroneously.
+   * @param  error            The error that occurred.
+   * @throws {NotFoundError}  When no matching correlation was found.
    */
-  finishWithError(correlationId: string, error: Error): Promise<void>;
+  finishProcessInstanceInCorrelationWithError(correlationId: string, error: Error): Promise<void>;
 }

--- a/src/icorrelation_service.ts
+++ b/src/icorrelation_service.ts
@@ -114,24 +114,29 @@ export interface ICorrelationService {
    * @param processModelId  The ID of the processModel, by which Correlations should be removed.
    */
   deleteCorrelationByProcessModelId(identity: IIdentity, processModelId: string): Promise<void>;
+
   /**
    * Finishes the given Correlation.
    *
    * @async
-   * @param  identity        The executing users identity.
-   * @param  correlationId   The ID of the Correlation to finish.
-   * @throws NotFoundError   When no matching correlation was found.
+   * @param  identity         The executing users identity.
+   * @param  correlationId    The ID of the Correlation to finish.
+   * @throws {NotFoundError}  When no matching correlation was found.
+   * @throws {ForbiddenError} When the user doesn't have access to the
+   *                          correlation.
    */
-  finishCorrelation(identity: IIdentity, correlationId: string): Promise<void>;
+  finishProcessInstanceInCorrelation(identity: IIdentity, correlationId: string): Promise<void>;
 
   /**
    * Finishes the given Correlation with an error.
    *
    * @async
-   * @param  identity        The executing users identity.
-   * @param  correlationId   The ID of the Correlation to finish erroneously.
-   * @param  error           The error that occurred.
-   * @throws NotFoundError   When no matching correlation was found.
+   * @param  identity         The executing users identity.
+   * @param  correlationId    The ID of the Correlation to finish erroneously.
+   * @param  error            The error that occurred.
+   * @throws {NotFoundError}  When no matching correlation was found.
+   * @throws {ForbiddenError} When the user doesn't have access to the
+   *                          correlation.
    */
-  finishWithError(identity: IIdentity, correlationId: string, error: Error): Promise<void>;
+  finishProcessInstanceInCorrelationWithError(identity: IIdentity, correlationId: string, error: Error): Promise<void>;
 }

--- a/src/icorrelation_service.ts
+++ b/src/icorrelation_service.ts
@@ -116,27 +116,29 @@ export interface ICorrelationService {
   deleteCorrelationByProcessModelId(identity: IIdentity, processModelId: string): Promise<void>;
 
   /**
-   * Finishes the given Correlation.
+   * Finishes the given ProcessInstance in the given Correlation.
    *
    * @async
-   * @param  identity         The executing users identity.
-   * @param  correlationId    The ID of the Correlation to finish.
-   * @throws {NotFoundError}  When no matching correlation was found.
-   * @throws {ForbiddenError} When the user doesn't have access to the
-   *                          correlation.
+   * @param  identity          The executing users identity.
+   * @param  correlationId     The ID of the Correlation to finish.
+   * @param  processInstanceId The ID of the ProcessInstance to finish.
+   * @throws {NotFoundError}   When no matching correlation was found.
+   * @throws {ForbiddenError}  When the user doesn't have access to the
+   *                           correlation.
    */
-  finishProcessInstanceInCorrelation(identity: IIdentity, correlationId: string): Promise<void>;
+  finishProcessInstanceInCorrelation(identity: IIdentity, correlationId: string, processInstanceId: string): Promise<void>;
 
   /**
-   * Finishes the given Correlation with an error.
+   * Finishes the given ProcessInstance in the given Correlation with an error.
    *
    * @async
-   * @param  identity         The executing users identity.
-   * @param  correlationId    The ID of the Correlation to finish erroneously.
-   * @param  error            The error that occurred.
-   * @throws {NotFoundError}  When no matching correlation was found.
-   * @throws {ForbiddenError} When the user doesn't have access to the
-   *                          correlation.
+   * @param  identity          The executing users identity.
+   * @param  correlationId     The ID of the Correlation to finish erroneously.
+   * @param  processInstanceId The ID of the ProcessInstance to finish.
+   * @param  error             The error that occurred.
+   * @throws {NotFoundError}   When no matching correlation was found.
+   * @throws {ForbiddenError}  When the user doesn't have access to the
+   *                           correlation.
    */
-  finishProcessInstanceInCorrelationWithError(identity: IIdentity, correlationId: string, error: Error): Promise<void>;
+  finishProcessInstanceInCorrelationWithError(identity: IIdentity, correlationId: string, processInstanceId: string, error: Error): Promise<void>;
 }


### PR DESCRIPTION
**Changes:**

Account for the ProcessInstanceId when attempting to finish something within a Correlation.

**Issues:**

Part of https://github.com/process-engine/process_engine_runtime/issues/274

PR: #2

## How can others test the changes?

Finishing a ProcessInstance in a Correlation will now work properly.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).