### PR TITLE
✨ Add Queries for retrieving ProcessInstances

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/correlation.contracts",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "description": "Contains the commonly used contracts for the Correlation API.",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/src/icorrelation_repository.ts
+++ b/src/icorrelation_repository.ts
@@ -1,7 +1,7 @@
 import {IIdentity} from '@essential-projects/iam_contracts';
 
 import {CorrelationState} from './types/correlation_state';
-import {CorrelationFromRepository} from './types/index';
+import {ProcessInstanceFromRepository} from './types/index';
 
 /**
  * The repository for accessing and manipulating correlations.
@@ -49,7 +49,7 @@ export interface ICorrelationRepository {
    * @param limit  Optional: The max. number of entries to return.
    * @returns A list of Correlations.
    */
-  getAll(offset?: number, limit?: number): Promise<Array<CorrelationFromRepository>>;
+  getAll(offset?: number, limit?: number): Promise<Array<ProcessInstanceFromRepository>>;
 
   /**
    * Gets all entries with a specific CorrelationId.
@@ -61,7 +61,7 @@ export interface ICorrelationRepository {
    * @returns               The retrieved Correlations.
    * @throws                404, If the Correlation was not found.
    */
-  getByCorrelationId(correlationId: string, offset?: number, limit?: number): Promise<Array<CorrelationFromRepository>>;
+  getByCorrelationId(correlationId: string, offset?: number, limit?: number): Promise<Array<ProcessInstanceFromRepository>>;
 
   /**
    * Gets all entries with a specific ProcessModelId.
@@ -73,7 +73,7 @@ export interface ICorrelationRepository {
    * @param   limit          Optional: The max. number of entries to return.
    * @returns                The retrieved Correlations.
    */
-  getByProcessModelId(processModelId: string, offset?: number, limit?: number): Promise<Array<CorrelationFromRepository>>;
+  getByProcessModelId(processModelId: string, offset?: number, limit?: number): Promise<Array<ProcessInstanceFromRepository>>;
 
   /**
    * Gets the entry that belongs to the given ProcessInstanceId.
@@ -86,7 +86,7 @@ export interface ICorrelationRepository {
    * @returns                   The retrieved Correlation.
    * @throws                    404, If the Correlation was not found.
    */
-  getByProcessInstanceId(processInstanceId: string): Promise<CorrelationFromRepository>;
+  getByProcessInstanceId(processInstanceId: string): Promise<ProcessInstanceFromRepository>;
 
   /**
    * Gets all entries that describe a Subprocess for the ProcessInstance with the
@@ -100,7 +100,7 @@ export interface ICorrelationRepository {
    * @returns                   The retrieved Correlations.
    *                            If none are found, an empty Array is returned.
    */
-  getSubprocessesForProcessInstance(processInstanceId: string, offset?: number, limit?: number): Promise<Array<CorrelationFromRepository>>;
+  getSubprocessesForProcessInstance(processInstanceId: string, offset?: number, limit?: number): Promise<Array<ProcessInstanceFromRepository>>;
 
   /**
    * Returns a list of all Correlations in the specified state.
@@ -111,7 +111,7 @@ export interface ICorrelationRepository {
    * @param   limit  Optional: The max. number of entries to return.
    * @returns        The retrieved Correlations.
    */
-  getCorrelationsByState(state: CorrelationState, offset?: number, limit?: number): Promise<Array<CorrelationFromRepository>>;
+  getCorrelationsByState(state: CorrelationState, offset?: number, limit?: number): Promise<Array<ProcessInstanceFromRepository>>;
 
   /**
    * Removes all Correlations with a specific ProcessModelId.

--- a/src/icorrelation_service.ts
+++ b/src/icorrelation_service.ts
@@ -5,13 +5,12 @@ import {Correlation, CorrelationState, ProcessInstance} from './types/index';
 /**
  * The Service for accessing the CorrelationRepository.
  *
- * Correlations combine a Correlation ID with a ProcessModel Hash.
- * This allows for implementing versioning of ProcessModels, as well
- * as keeping track on how a ProcessModel looked at the time a certain
- * Correlation was run.
+ * Correlations combine a Correlation ID and ProcessInstance with a ProcessModel Hash.
+ * This allows for implementing versioning of ProcessModels, as well as keeping
+ * track on how a ProcessModel looked at the time a certain ProcessInstance was run.
  *
- * Note that a ProcessModel instance will only belong to one Correlation,
- * but a Correlation can have multiple ProcessModel instances.
+ * Note that a ProcssInstance will only belong to one Correlation,
+ * but a Correlation can have multiple ProcssInstances.
  */
 export interface ICorrelationService {
 

--- a/src/icorrelation_service.ts
+++ b/src/icorrelation_service.ts
@@ -1,6 +1,6 @@
 import {IIdentity} from '@essential-projects/iam_contracts';
 
-import {Correlation} from './types/index';
+import {Correlation, ProcessInstance} from './types/index';
 
 /**
  * The Service for accessing the CorrelationRepository.
@@ -88,31 +88,27 @@ export interface ICorrelationService {
   getByProcessModelId(identity: IIdentity, processModelId: string, offset?: number, limit?: number): Promise<Array<Correlation>>;
 
   /**
-   * Gets the entry that belongs to the given ProcessInstanceId.
-   * Note that ProcessInstanceIds are always unique, so this will always
-   * return only one entry.
+   * Gets a ProcessInstance by its ID.
    *
    * @async
    * @param identity          The executing users identity.
-   * @param processInstanceId The ID of the ProcessInstance for which to retrieve
-   *                          the Correlations.
-   * @returns                 The retrieved Correlation.
-   * @throws                  404, If the Correlation was not found.
+   * @param processInstanceId The ID of the ProcessInstance to get.
+   * @returns                 The retrieved ProcessInstance.
+   * @throws                  404, If the ProcessInstance was not found.
    */
-  getByProcessInstanceId(identity: IIdentity, processInstanceId: string): Promise<Correlation>;
+  getByProcessInstanceId(identity: IIdentity, processInstanceId: string): Promise<ProcessInstance>;
 
   /**
-   * Gets a Correlation-Object that contains all Subprocesses for the given
-   * ProcessInstanceId.
+   * Gets all ProcessInstances that run as a Subprocess for the given ProcessInstanceId.
    *
    * @async
    * @param identity          The executing users identity.
    * @param processInstanceId The ID of the ProcessInstance for which to retrieve
-   *                          the SubProcess-Correlations.
-   * @returns                 The retrieved Correlations.
+   *                          the SubProcessInstances.
+   * @returns                 The retrieved SubProcessInstances.
    *                          If none are found, an empty Array is returned.
    */
-  getSubprocessesForProcessInstance(identity: IIdentity, processInstanceId: string): Promise<Correlation>;
+  getSubprocessesForProcessInstance(identity: IIdentity, processInstanceId: string): Promise<Array<ProcessInstance>>;
 
   /**
    * Removes all Correlations with a specific ProcessModelId.

--- a/src/icorrelation_service.ts
+++ b/src/icorrelation_service.ts
@@ -1,6 +1,6 @@
 import {IIdentity} from '@essential-projects/iam_contracts';
 
-import {Correlation, ProcessInstance} from './types/index';
+import {Correlation, CorrelationState, ProcessInstance} from './types/index';
 
 /**
  * The Service for accessing the CorrelationRepository.
@@ -105,10 +105,48 @@ export interface ICorrelationService {
    * @param identity          The executing users identity.
    * @param processInstanceId The ID of the ProcessInstance for which to retrieve
    *                          the SubProcessInstances.
+   * @param offset            Optional: The number of records to skip.
+   * @param limit             Optional: The max. number of entries to return.
    * @returns                 The retrieved SubProcessInstances.
    *                          If none are found, an empty Array is returned.
    */
-  getSubprocessesForProcessInstance(identity: IIdentity, processInstanceId: string): Promise<Array<ProcessInstance>>;
+  getSubprocessesForProcessInstance(identity: IIdentity, processInstanceId: string, offset?: number, limit?: number): Promise<Array<ProcessInstance>>;
+
+  /**
+   * Gets a list of all ProcessInstances that run in the given Correlation.
+   *
+   * @async
+   * @param   identity       The executing users identity.
+   * @param   correlationId  The ID of the correlation for which to get the ProcessInstances.
+   * @param   offset         Optional: The number of records to skip.
+   * @param   limit          Optional: The max. number of entries to return.
+   * @returns                A list with matching ProcessInstances; or an empty Array, if non were found.
+   */
+  getProcessInstancesForCorrelation(identity: IIdentity, correlationId: string, offset?: number, limit?: number): Promise<Array<ProcessInstance>>;
+
+  /**
+   * Gets a list of all ProcessInstances for the given ProcessModel.
+   *
+   * @async
+   * @param   identity        The executing users identity.
+   * @param   processModelId  The ID of the ProcessModel for which to get the ProcessInstances.
+   * @param   offset          Optional: The number of records to skip.
+   * @param   limit           Optional: The max. number of entries to return.
+   * @returns                 A list with matching ProcessInstances; or an empty Array, if non were found.
+   */
+  getProcessInstancesForProcessModel(identity: IIdentity, processModelId: string, offset?: number, limit?: number): Promise<Array<ProcessInstance>>;
+
+  /**
+   * Gets a list of all ProcessInstances that are in a matching state.
+   *
+   * @async
+   * @param   identity The executing users identity.
+   * @param   state    the state by which to query the ProcessInstances.
+   * @param   offset   Optional: The number of records to skip.
+   * @param   limit    Optional: The max. number of entries to return.
+   * @returns          A list with matching ProcessInstances; or an empty Array, if non were found.
+   */
+  getProcessInstancesByState(identity: IIdentity, state: CorrelationState, offset?: number, limit?: number): Promise<Array<ProcessInstance>>;
 
   /**
    * Removes all Correlations with a specific ProcessModelId.

--- a/src/types/correlation.ts
+++ b/src/types/correlation.ts
@@ -1,4 +1,4 @@
-import {CorrelationProcessInstance} from './correlation_process_instance';
+import {ProcessInstance} from './process_instance';
 import {CorrelationState} from './correlation_state';
 
 /**
@@ -7,7 +7,7 @@ import {CorrelationState} from './correlation_state';
 export class Correlation {
 
   public id: string;
-  public processInstances: Array<CorrelationProcessInstance>;
+  public processInstances: Array<ProcessInstance>;
   public state: CorrelationState;
   public error: Error;
   public createdAt?: Date;

--- a/src/types/correlation_process_instance.ts
+++ b/src/types/correlation_process_instance.ts
@@ -7,12 +7,13 @@ import {CorrelationState} from './correlation_state';
  */
 export class CorrelationProcessInstance {
 
+  public correlationId: string;
   public processDefinitionName: string;
-  public hash: string;
-  public xml: string;
   public processModelId: string;
   public processInstanceId?: string;
   public parentProcessInstanceId?: string;
+  public hash: string;
+  public xml: string;
   public state: CorrelationState;
   public error: Error;
   public identity: IIdentity;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,4 @@
-export * from './correlation_from_repository';
 export * from './correlation_state';
 export * from './correlation';
+export * from './process_instance_from_repository';
 export * from './process_instance';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,4 @@
 export * from './correlation_from_repository';
-export * from './correlation_process_instance';
 export * from './correlation_state';
 export * from './correlation';
+export * from './process_instance';

--- a/src/types/process_instance.ts
+++ b/src/types/process_instance.ts
@@ -3,9 +3,9 @@ import {IIdentity} from '@essential-projects/iam_contracts';
 import {CorrelationState} from './correlation_state';
 
 /**
- * Describes a ProcessInstance within a Correlation.
+ * Describes a ProcessInstance.
  */
-export class CorrelationProcessInstance {
+export class ProcessInstance {
 
   public correlationId: string;
   public processDefinitionName: string;

--- a/src/types/process_instance_from_repository.ts
+++ b/src/types/process_instance_from_repository.ts
@@ -7,7 +7,7 @@ import {CorrelationState} from './correlation_state';
  */
 export class ProcessInstanceFromRepository {
 
-  public id: string;
+  public correlationId: string;
   public processModelHash: string;
   public processModelId: string;
   public processInstanceId: string;

--- a/src/types/process_instance_from_repository.ts
+++ b/src/types/process_instance_from_repository.ts
@@ -3,9 +3,9 @@ import {IIdentity} from '@essential-projects/iam_contracts';
 import {CorrelationState} from './correlation_state';
 
 /**
- * Describes a Correlation, as it is stored in the CorrelationRepository.
+ * Describes a ProcessInstance as it is stored in the database.
  */
-export class CorrelationFromRepository {
+export class ProcessInstanceFromRepository {
 
   public id: string;
   public processModelHash: string;


### PR DESCRIPTION
## Changes

1. Rename `CorrelationFromRepository` to `ProcessInstanceFromRepository`
2. Rename `CorrelationProcessInstance` to `ProcessInstance`
3. Add `correlationId` property to `ProcessInstance` type
4. Change return type of `ICorrelationService.getByProcessInstanceId` to `ProcessInstance`
5. Change return type of `getSubprocessesForProcessInstance` to `Array<ProcessInstance>`
6. Add UseCases for getting ProcessInstances:
    - getProcessInstancesForCorrelation
    - getProcessInstancesForProcessModel
    - getProcessInstancesByState

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/404

PR: #5